### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/deployment/shot-detection-demo.yaml
+++ b/deployment/shot-detection-demo.yaml
@@ -32,7 +32,7 @@ Mappings:
             SortKey: keyword
     Node:
         Runtime:
-            Version: nodejs10.x
+            Version: nodejs14.x
 
 Parameters:
     Email:
@@ -518,7 +518,7 @@ Resources:
                 }
             ]
             CompatibleRuntimes:
-                - nodejs10.x
+                - nodejs14.x
                 - nodejs12.x
             Content:
                 S3Bucket: !Sub [
@@ -586,7 +586,7 @@ Resources:
                 }
             ]
             CompatibleRuntimes:
-                - nodejs10.x
+                - nodejs14.x
                 - nodejs12.x
             Content:
                 S3Bucket: !Sub [
@@ -654,7 +654,7 @@ Resources:
                 }
             ]
             CompatibleRuntimes:
-                - nodejs10.x
+                - nodejs14.x
                 - nodejs12.x
             Content:
                 S3Bucket: !Sub [


### PR DESCRIPTION
CloudFormation templates in amazon-rekognition-shot-detection-demo-using-segment-api have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.